### PR TITLE
Condition value to null

### DIFF
--- a/src/whereConditions.ts
+++ b/src/whereConditions.ts
@@ -35,11 +35,10 @@ export const makeWherePrisma2Compatible = (input: any): any => {
       if (['AND', 'OR', 'NOT'].includes(operator)) {
         transformedWhere[operator] = transformNestedOperators(val);
       } else {
-        if (typeof val === 'object' && !Array.isArray(val)) {
-          transformedWhere[operator] = transformNestedOperators(val);
-        } else {
-          transformedWhere[operator] = val;
-        }
+        transformedWhere[operator] =
+          typeof val === 'object' && !Array.isArray(val) && val !== null
+          ? transformNestedOperators(val)
+          : val;
       }
     } else {
       const field = key.slice(0, index);

--- a/src/whereConditions.ts
+++ b/src/whereConditions.ts
@@ -35,10 +35,11 @@ export const makeWherePrisma2Compatible = (input: any): any => {
       if (['AND', 'OR', 'NOT'].includes(operator)) {
         transformedWhere[operator] = transformNestedOperators(val);
       } else {
-        transformedWhere[operator] =
-          typeof val === 'object' && !Array.isArray(val) && val !== null
-          ? transformNestedOperators(val)
-          : val;
+        if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
+          transformedWhere[operator] = transformNestedOperators(val);
+        } else {
+          transformedWhere[operator] = val;
+        }
       }
     } else {
       const field = key.slice(0, index);

--- a/test/whereCondition.test.ts
+++ b/test/whereCondition.test.ts
@@ -250,7 +250,7 @@ it('correctly works on relation related operators', () => {
       title: {
         contains: 'searchstring',
       },
-      reviewer: null
+      reviewer: null,
     },
   });
 });

--- a/test/whereCondition.test.ts
+++ b/test/whereCondition.test.ts
@@ -237,4 +237,20 @@ it('correctly works on relation related operators', () => {
       },
     },
   });
+
+  expect(
+    makeWherePrisma2Compatible({
+      posts: {
+        title_contains: 'searchstring',
+        reviewer: null,
+      },
+    })
+  ).toEqual({
+    posts: {
+      title: {
+        contains: 'searchstring',
+      },
+      reviewer: null
+    },
+  });
 });


### PR DESCRIPTION
Fixed bug:
if where condition looks like 
```
user: {
    posts_some: {
        published: true
    },
    reviewer: null
}
```
was throw an error "TypeError: Cannot convert undefined or null to object"